### PR TITLE
fix location of optionalServices

### DIFF
--- a/button-demo/index.html
+++ b/button-demo/index.html
@@ -44,9 +44,9 @@
             navigator.bluetooth.requestDevice({
                     filters: [{
                         services: [serviceUUID],
-                        //optionalServices: optionalServicesUUID
                         //"name": "Thingy"
-                    }]
+                    }],
+                    //optionalServices: optionalServicesUUID
                 })
                 .then(device => {
                     bleDevice = device;


### PR DESCRIPTION
Not sure where `name:` goes, but `optionalServices` go outside of `filters:`
See the documentation here: https://webbluetoothcg.github.io/web-bluetooth/#example-filter-by-services